### PR TITLE
Shortening README and linking to a real project

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Social Login (Facebook)                     | [FacebookAuthenticator](https://gi
 
 ## Contributing
 
-Find a bug or a use-case that this doesn't support? [Open an Issue]() so we can make
-things better.
+Find a bug or a use-case that this doesn't support? [Open an Issue](https://github.com/knpuniversity/KnpUGuardBundle/issues)
+so we can make things better.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,125 +9,32 @@ is not guaranteed yet. The original purpose was to get feedback and use-cases
 from people so that we can merge this feature into Symfony itself
 (see [symfony/symfony#14673](https://github.com/symfony/symfony/pull/14673)).
 
-## Installation
+## Documentation
 
-**This bundle requires Symfony 2.6 or higher.**
+Find a full tutorial here: https://knpuniversity.com/screencast/guard
 
-First, wave your [composer](https://getcomposer.org/) wand to install things:
+## Basic Usage
 
-```bash
-composer require knpuniversity/guard-bundle:dev-master
-```
+Check out the [Tutorial](https://knpuniversity.com/screencast/guard) for real documentation.
+But here's the basic idea.
 
-Next, plug the bundle into your `app/AppKernel.php` file:
+Guard works by creating a single class - an **authenticator** - that handles *everything*
+about how you want to authenticate your users. And authenticator implements
+[KnpU\GuardBundle\Guard\GuardAuthenticatorInterface](https://github.com/knpuniversity/KnpUGuard/blob/master/src/GuardAuthenticatorInterface.php))
 
-```php
-public function registerBundles()
-{
-    $bundles = array(
-        // -> add just this ONE line
-        new KnpU\GuardBundle\KnpUGuardBundle(),
-    );
+Here are some real-world examples from the tutorial:
 
-    // ...
-}
-```
+Goal                                        | Code                                                                                                                                      | Tutorial
+------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------
+Authenticate by reading an `X-TOKEN` header | [ApiTokenAuthenticator](https://github.com/knpuniversity/guard-tutorial/blob/finished/src/AppBundle/Security/ApiTokenAuthenticator.php)   | https://knpuniversity.com/screencast/guard/api-token
+Form login authentication                   | [FormLoginAuthenticator](https://github.com/knpuniversity/guard-tutorial/blob/finished/src/AppBundle/Security/FormLoginAuthenticator.php) | https://knpuniversity.com/screencast/guard/login-form
+Social Login (Facebook)                     | [FacebookAuthenticator](https://github.com/knpuniversity/guard-tutorial/blob/finished/src/AppBundle/Security/FacebookAuthenticator.php)   | https://knpuniversity.com/screencast/guard/social-login
 
-Now, start using it!
+## Contributing
 
-## Usage
+Find a bug or a use-case that this doesn't support? [Open an Issue]() so we can make
+things better.
 
-For an example application, see [knpuniversity/symfony-guard-demo](https://github.com/knpuniversity/symfony-guard-demo).
+## License
 
-Whether you want to authenticate via a form login, by reading an API token
-or both, you'll follow the same 3-step process:
-
-### 1) Create an Authenticator class
-
-Each time you want to authenticate a user, you'll start by creating a class
-that extends [KnpU\GuardBundle\Guard\AbstractGuardAuthenticator](https://github.com/knpuniversity/KnpUGuardBundle/blob/master/Guard/AbstractGuardAuthenticator.php)
-(or implements [KnpU\GuardBundle\Guard\GuardAuthenticatorInterface](https://github.com/knpuniversity/KnpUGuardBundle/blob/master/Guard/GuardAuthenticatorInterface.php)).
-For examples, see [TokenAuthenticator](https://github.com/knpuniversity/symfony-guard-demo/blob/master/src/AppBundle/Security/TokenAuthenticator.php)
-and [FormLoginAuthenticator](https://github.com/knpuniversity/symfony-guard-demo/blob/master/src/AppBundle/Security/FormLoginAuthenticator.php).
-
-This interface has a method for every part of the authentication process,
-from fetching the credentials (e.g. username/password or API token) from
-the request to handling success and error situations.
-
-### 2) Create a User Provider
-
-A User Provider is basically a class that knows how to load your "users".
-It's passed to the `getUser()` method of your authenticator. Whether you
-are loading users from a database or elsewhere, I recommend creating your
-own user provider class.
-
-For example, see [UserProvider](https://github.com/knpuniversity/symfony-guard-demo/blob/master/src/AppBundle/Security/UserProvider.php)
-from the demo project.
-
-### 3) Register the authenticator (and user provider) as a service
-
-The authenticators are plain old services, so this is easy. For example,
-
-```yml
-# app/config/services.yml
-services:
-    app.form_login_authenticator:
-        class: AppBundle\Security\FormLoginAuthenticator
-        arguments: ['@security.password_encoder', '@router']
-
-    app.token_authenticator:
-        class: AppBundle\Security\TokenAuthenticator
-        arguments: []
-
-   app.user_provider:
-        class: AppBundle\Security\UserProvider
-        arguments: ['@doctrine.orm.entity_manager']
-```
-
-### 4) Configure security.yml
-
-For a full example `security.yml`, see [security.yml](https://github.com/knpuniversity/symfony-guard-demo/blob/master/app/config/security.yml)
-in the demo app.
-
-There are basically only two critical areas to configure: `providers`
-and `firewalls`:
-
-```yml
-security:
-    encoders:
-        AppBundle\Entity\User: bcrypt
-
-    providers:
-        # the service id to your provider (you can also use other providers,
-        # like the "entity" provider)
-        main_provider:
-            id: app.user_provider
-
-    firewalls:
-        secured_area:
-            # this firewall applies to all URLs
-            pattern: ^/
-            anonymous: true
-
-            knpu_guard:
-                authenticators:
-                    - app.form_login_authenticator
-                    - app.token_authenticator
-                # provider: main_provider
-
-                # since you have 2 authenticators, you'll choose which "start"
-                # method is called when the user should be asked to login
-                # entry_point: app.token_authenticator
-                entry_point: app.form_login_authenticator
-
-            # any other keys, like remember_me, switch_user, logout, etc
-
-    # ...
-```
-
-First, you'll register your user provider under the `providers` key. Next,
-add a `knpu_guard` key under your firewall with an `authenticators` key.
-Here, put the service ids of all your authenticators: you may have just one.
-
-That's it! Your authenticators should be called on every request, and they
-can authenticate to their heart's desire.
+This library is under the MIT license. See the complete license in the LICENSE file.


### PR DESCRIPTION
This shortens the readme to avoid duplication and point people to the tutorial, which we can keep up to date.

I've included a link to the documentation and a basic usage section (so that people can get an idea of whether or not this is what they need before needing to click further).
